### PR TITLE
Change <void> to <> for 4.23 compatibility.

### DIFF
--- a/Source/DedicatedServer/Private/DedicatedServer.cpp
+++ b/Source/DedicatedServer/Private/DedicatedServer.cpp
@@ -42,7 +42,7 @@ void FDedicatedServerModule::StartupModule()
 					GLog->AddOutputDevice( GLogConsole );
 				}
 
-				m_hTick = Async<void>( EAsyncExecution::Thread, [this]() -> void
+				m_hTick = Async<>( EAsyncExecution::Thread, [this]() -> void
 				{
 					while( !m_bShutdown )
 					{


### PR DESCRIPTION
Apparently this is now inferred, and specifying it was causing a compiler error.

Related conversation: https://forums.unrealengine.com/development-discussion/c-gameplay-programming/1650841-async-call-with-calltype